### PR TITLE
Add autocomplete template option in YAML

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -421,6 +421,10 @@ async function configYamlToContinueConfig(options: {
     continueConfig.contextProviders.push(new DocsContextProvider({}));
   }
 
+  if (config.tabAutocompleteOptions) {
+    continueConfig.tabAutocompleteOptions = config.tabAutocompleteOptions;
+  }
+
   // Trigger MCP server refreshes (Config is reloaded again once connected!)
   const mcpManager = MCPManagerSingleton.getInstance();
   mcpManager.setConnections(

--- a/docs/docs/yaml-migration.md
+++ b/docs/docs/yaml-migration.md
@@ -343,9 +343,10 @@ The following top-level fields from `config.json` still work when using `config.
   - `debounceDelay`
   - `maxSuffixPercentage`
   - `prefixPercentage`
-  - `template`
   - `onlyMyCode`
 - `analytics`
+
+The `template` option under `tabAutocompleteOptions` is supported in YAML and can be used to specify a custom inline completion template.
 
 The following top-level fields from `config.json` have been deprecated. Most UI-related and user-specific options will move into a settings page in the UI
 

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -210,6 +210,24 @@ const toolSchema = z.object({
 
 export const autoindentExtensionsSchema = z.array(z.string());
 
+export const tabAutocompleteOptionsSchema = z.object({
+  disable: z.boolean().optional(),
+  maxPromptTokens: z.number().optional(),
+  debounceDelay: z.number().optional(),
+  maxSuffixPercentage: z.number().optional(),
+  prefixPercentage: z.number().optional(),
+  transform: z.boolean().optional(),
+  template: z.string().optional(),
+  multilineCompletions: z.enum(["always", "never", "auto"]).optional(),
+  slidingWindowPrefixPercentage: z.number().optional(),
+  slidingWindowSize: z.number().optional(),
+  useCache: z.boolean().optional(),
+  onlyMyCode: z.boolean().optional(),
+  useRecentlyEdited: z.boolean().optional(),
+  disableInFiles: z.array(z.string()).optional(),
+  useImports: z.boolean().optional(),
+});
+
 export const configSchema = z.object({
   models: z.array(modelSchema).optional(),
   defaultModel: z.string().optional(),
@@ -220,6 +238,7 @@ export const configSchema = z.object({
   langMarkers: z.array(languageMarkerSchema).optional(),
   sidebar: sidebarSchema.optional(),
   tabAutocompleteModel: z.string().optional(),
+  tabAutocompleteOptions: tabAutocompleteOptionsSchema.optional(),
   rules: z.array(ruleObjectSchema).optional(),
   doneWithBannerForever: z.boolean().optional(),
   autoindentExtensions: autoindentExtensionsSchema.optional(),


### PR DESCRIPTION
## Summary
- extend YAML schema with `tabAutocompleteOptions` including a `template` field
- pass `tabAutocompleteOptions` through YAML config loader
- document support for the template option in the migration guide

## Testing
- `npm test --prefix packages/config-yaml`
- `npm test --prefix packages/hub -- --passWithNoTests`
- `npm test --prefix packages/fetch`
- `npm test --prefix packages/openai-adapters` *(fails: missing OPENAI_API_KEY)*
- `npm test --prefix packages/continue-sdk/typescript` *(fails: Jest config error)*

------
https://chatgpt.com/codex/tasks/task_e_6842c795626c832c8e5da50f98dbeb17